### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ resource_types:
     type: docker-image
     source:
       repository: olhtbr/metadata-resource
-      tag: 2.0.0
+      tag: 2.0.1
 
 resources:
   # The resource does not need any configuration


### PR DESCRIPTION
readme should reflect the latest version 2.0.1 while defining the resource-type. With 2.0.0 I found a problem that in a pipeline having multiple jobs using the same or dedicated `metadata` resource-instances with `put` to for unique build url for specific jobs, was completely messed up and each job were getting `job-names` of other jobs. With tag 2.0.1, the problem away.